### PR TITLE
Support literals (number, string, boolean, null, regexp).

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -58,6 +58,29 @@ export function translateProgram(program: ts.Program): string {
         ts.forEachChild(node, visit);
         emit(';\n');
         break;
+      case ts.SyntaxKind.ExpressionStatement:
+        var expr = <ts.ExpressionStatement>node;
+        visit(expr.expression);
+        emit(';');
+        break;
+
+      // Literals.
+      case ts.SyntaxKind.StringLiteral:
+        var sLit = <ts.StringLiteralExpression>node;
+        emit(JSON.stringify(sLit.text));
+        break;
+      case ts.SyntaxKind.TrueKeyword:
+        emit('true');
+        break;
+      case ts.SyntaxKind.FalseKeyword:
+        emit('false');
+        break;
+      case ts.SyntaxKind.NullKeyword:
+        emit('null');
+        break;
+      case ts.SyntaxKind.RegularExpressionLiteral:
+        emit((<ts.LiteralExpression>node).text);
+        break;
 
       case ts.SyntaxKind.FirstAssignment:
       case ts.SyntaxKind.FirstLiteralToken:

--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -34,6 +34,33 @@ describe('transpile to dart', function() {
       expectTranslate("class X extends Y implements Z {}").to.equal(" class X extends Y implements Z {\n }\n");
     })
   });
+
+  describe('literals', function() {
+    it('translates string literals', function() {
+      expectTranslate(`'hello\\\\' "world'`).to.equal(` "hello' \\\\"world" ;`);
+      expectTranslate(`"hello\\\\" 'world"`).to.equal(` "hello\\\\" 'world" ;`);
+    });
+
+    it('translates boolean literals', function() {
+      expectTranslate('true').to.equal(' true ;');
+      expectTranslate('false').to.equal(' false ;');
+    });
+
+    it('translates the null literal', function() {
+      expectTranslate('null').to.equal(' null ;');
+    });
+
+    it('translates number literals', function() {
+      // Negative numbers are handled by unary minus expressions.
+      expectTranslate('1234').to.equal(' 1234 ;');
+      expectTranslate('12.34').to.equal(' 12.34 ;');
+      expectTranslate('1.23e-4').to.equal(' 1.23e-4 ;');
+    });
+
+    it('translates regexp literals', function() {
+      expectTranslate('/wo\\/t?/').to.equal(' /wo\\/t?/ ;');
+    });
+  });
 });
 
 export function translateSource(contents: string): string {
@@ -61,7 +88,7 @@ export function translateSource(contents: string): string {
   if (program.getDiagnostics().length > 0) {
     // Throw first error.
     var first = program.getDiagnostics()[0];
-    throw new Error(`${first.start}: ${first.messageText}`);
+    throw new Error(`${first.start}: ${first.messageText} in ${contents}`);
   }
   return main.translateProgram(program);
 }


### PR DESCRIPTION
Does not include string templates.