### PR TITLE
Refactor the giant-switch-in-a-closure to a class

### DIFF
--- a/test/DartTest.ts
+++ b/test/DartTest.ts
@@ -114,6 +114,13 @@ describe('transpile to dart', function() {
           .to.equal(' switch ( x ) { case 1 : break ; case 2 : break ; default : break ; }');
     });
   });
+
+  describe('comments', () => {
+    it('keeps leading comments', () => {
+      expectTranslate('/* A */ a\n /* B */ b').to.equal(' /* A */ a ; /* B */ b ;');
+      expectTranslate('// A\na\n// B\nb').to.equal(' // A\n a ; // B\n b ;');
+    });
+  });
 });
 
 export function translateSource(contents: string): string {


### PR DESCRIPTION
With previous changes we now have two pieces of state accessed during the switch (result and lastCommentIdx), and we'll likely add more (e.g. a list of errors instead of throwing them immediately. So let's move this into a class before we end up with gigantic nested scopes.

The drawback is repeating `this` a lot :-(